### PR TITLE
Remove verbose output from pip installation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ python:
   - "2.7"
 
 # command to install dependencies
-install: "pip install -r requirements.txt --use-mirrors"
+install: "pip install --use-mirrors -q -r requirements.txt"
 
 # command to run tests
 script: python runtests.py


### PR DESCRIPTION
Use the -q flag for pip installation in Travis.
