### PR TITLE
Drop pip usage of --use-mirrors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ python:
   - "2.7"
 
 # command to install dependencies
-install: "pip install --use-mirrors -q -r requirements.txt"
+install: "pip install -q -r requirements.txt"
 
 # command to run tests
 script: python runtests.py


### PR DESCRIPTION
https://github.com/pypa/pip/pull/1098 - unsupported, dangerous, slow,
etc.