### PR TITLE
Fix testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.pyc
+/.tox
 /build
 /dist

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+sudo: false
 
 install:
     - pip install tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
 language: python
-python:
-  - "2.7"
 
-# command to install dependencies
-install: "pip install --use-mirrors -q -r requirements.txt"
+install:
+    - pip install tox
 
-# command to run tests
-script: python runtests.py
+script:
+    - tox
+
+env:
+    - TOXENV=django15
+    - TOXENV=django16

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,6 @@ script:
     - tox
 
 env:
+    - TOXENV=django14
     - TOXENV=django15
     - TOXENV=django16

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,9 @@
 language: python
+
+python:
+    - "2.6"
+    - "2.7"
+
 sudo: false
 
 install:

--- a/pyroven/__init__.py
+++ b/pyroven/__init__.py
@@ -199,7 +199,7 @@ class RavenResponse(object):
         
         # Check that it matches
         try:
-            verify(cert, self.sig, data, 'sha1')
+            verify(cert, self.sig, str(data), 'sha1')
         except Exception, e:
             raise InvalidResponseError("The signature for this "
                                         "response is not valid.")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,0 @@
-django
-PyOpenSSL

--- a/setup.py
+++ b/setup.py
@@ -16,5 +16,8 @@ setup(name='django-pyroven',
       maintainer='Kristian Glass',
       maintainer_email='pyroven@doismellburning.co.uk',
       packages=['pyroven'],
-      install_requires=['pyOpenSSL'],
+      install_requires=[
+          'Django<1.7',
+          'pyOpenSSL',
+      ],
       )

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [tox]
-basepython = python2.7
-envlist = django14, django15, django16
+envlist = py26, py27, django14, django15, django16
 
 [base]
 deps = PyOpenSSL

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,19 @@
+[tox]
+basepython = python2.7
+envlist = django15, django16
+
+[base]
+deps = PyOpenSSL
+
+[testenv]
+commands = python runtests.py
+
+[testenv:django15]
+deps =
+    django>=1.5,<1.6
+    {[base]deps}
+
+[testenv:django16]
+deps =
+    django>=1.6,<1.7
+    {[base]deps}

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, django14, django15, django16
+envlist = django14, django15, django16
 
 [base]
 deps = PyOpenSSL

--- a/tox.ini
+++ b/tox.ini
@@ -1,23 +1,19 @@
 [tox]
+skipsdist = True
 envlist = django14, django15, django16
 
-[base]
-deps = PyOpenSSL
-
 [testenv]
+usedevelop = True
 commands = python runtests.py
 
 [testenv:django14]
 deps =
     django>=1.4,<1.5
-    {[base]deps}
 
 [testenv:django15]
 deps =
     django>=1.5,<1.6
-    {[base]deps}
 
 [testenv:django16]
 deps =
     django>=1.6,<1.7
-    {[base]deps}

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,17 @@
 [tox]
 basepython = python2.7
-envlist = django15, django16
+envlist = django14, django15, django16
 
 [base]
 deps = PyOpenSSL
 
 [testenv]
 commands = python runtests.py
+
+[testenv:django14]
+deps =
+    django>=1.4,<1.5
+    {[base]deps}
 
 [testenv:django15]
 deps =


### PR DESCRIPTION
This PR changes the following:

1. Use tox for testing to facilitate build matrix
2. Fixes pyroven/django-pyroven#21 by ensuring a bytestring, rather than a unicode string is passed to the [```OpenSSL.crypto.verify()```](https://pyopenssl.readthedocs.org/en/latest/api/crypto.html#OpenSSL.crypto.verify) method
3. Addresses pyroven/django-pyroven#19 - we can run on (```django>=1.4,<1.7```), and ```python 2.6, 2.7```
4. Addresses pyroven/django-pyroven#18 - removes the insecure ```--use-mirrors``` flag (and ```-q```)
5. Moves to the docker architecture on Travis, which speeds up builds

This does not fix running on ```django >= 1.7```, which requires a further change due to the changes in application loading. See pyroven/django-pyroven#17 for a separate issue on that.