### PR TITLE
Include build status in the Readme. Have a description in the title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# Introduction
+# Pyroven: Cambridge University Raven integration for Django
+
+[![Build Status](https://travis-ci.org/pyroven/django-pyroven.svg?branch=master)](https://travis-ci.org/pyroven/django-pyroven)
 
 pyroven is a library which provides use of Cambridge University's [Raven authentication](http://raven.cam.ac.uk/) for [Django](https://www.djangoproject.com/). It provides a Django authentication backend which can be added to `AUTHENTICATION_BACKENDS` in the Django `settings` module.
 


### PR DESCRIPTION
Might be a bit preference-dependent. I quite like having the Travis build status in the README on Github, as then you check it out and see the build status immediately. I also think we could have a more descriptive README title than we do at present, which succinctly describes the role of the library.