### PR TITLE
Reinstate long_description

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,8 +6,7 @@ from distutils.core import setup
 
 setup(name='django-pyroven',
       description='A Django authentication backend for Ucam-WebAuth / Raven',
-#     No long_description due to http://bugs.python.org/issue13614
-#     long_description=open('README.md').read(),
+      long_description=open('README.md').read(),
       url='https://github.com/pyroven/django-pyroven',
       version='0.9',
       license='MIT',


### PR DESCRIPTION
Reinstates long_description due to fixing of Python [bug 13614](http://bugs.python.org/issue13614). Resolves issue pyroven/django-pyroven#29