### PR TITLE
Test against Django 1.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,5 @@ env:
     - TOXENV=django14
     - TOXENV=django15
     - TOXENV=django16
+    - TOXENV=django17
     - TOXENV=flake8

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(name='django-pyroven',
       maintainer_email='pyroven@doismellburning.co.uk',
       packages=['pyroven'],
       install_requires=[
-          'Django<1.7',
+          'Django',
           'pyOpenSSL',
       ],
       classifiers=[

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist = True
-envlist = django14, django15, django16, flake8
+envlist = django14, django15, django16, django17, flake8
 
 [testenv]
 usedevelop = True
@@ -19,6 +19,10 @@ deps =
 [testenv:django16]
 deps =
     django>=1.6,<1.7
+
+[testenv:django17]
+deps =
+    django>=1.7,<1.8
 
 [testenv:flake8]
 deps =


### PR DESCRIPTION
Tox successfully passes the tests, so there is no reason not to run against Django 1.7. References pyroven/django-pyroven#17
